### PR TITLE
improvement: adds tag clustername

### DIFF
--- a/env/jx-app-datadog/values.tmpl.yaml
+++ b/env/jx-app-datadog/values.tmpl.yaml
@@ -1,10 +1,10 @@
 datadog:
   datadog:
     apiKey: vault:datadog-app:apiKey
-    clusterName: hornberyl
+    clusterName: "{{ .Requirements.cluster.clusterName }}"
     tags:
       - env:staging
-      - clustername:hornberyl
+      - clustername:"{{ .Requirements.cluster.clusterName }}"
     nonLocalTraffic: true
     collectEvents: true
     leaderElection: true

--- a/env/jx-app-datadog/values.tmpl.yaml
+++ b/env/jx-app-datadog/values.tmpl.yaml
@@ -4,6 +4,7 @@ datadog:
     clusterName: hornberyl
     tags:
       - env:staging
+      - clustername:hornberyl
     nonLocalTraffic: true
     collectEvents: true
     leaderElection: true


### PR DESCRIPTION
Some metrics doesn't provide tag clustername. Adding it at this level permits to filter metrics more easily on DataDog UI.